### PR TITLE
Fix: Enable Usage UI and resolve render loop in Incognito Mode

### DIFF
--- a/content-components/content_utils.js
+++ b/content-components/content_utils.js
@@ -708,6 +708,16 @@ async function initExtension() {
 	CONFIG = await sendBackgroundMessage({ type: 'getConfig' });
 	await Log("Config received...");
 
+	// Incognito conversations never have the standard sidebar structure.
+    // Skip the 6-second wait to avoid a spurious warning and wasted polling.
+    if (new URLSearchParams(window.location.search).has('incognito')) {
+        await Log('Incognito mode: skipping sidebar anchor wait');
+        sendBackgroundMessage({ type: 'requestData' });
+        sendBackgroundMessage({ type: 'initOrg' });
+        await Log('Initialization complete. Ready to track tokens.');
+        return;
+    }
+
 	// Wait for page to be ready (sidebar anchor available = logged in and DOM loaded)
 	const LOGIN_CHECK_DELAY = 10000;
 	while (true) {


### PR DESCRIPTION
**Problem:** 
Incognito mode (`/new?incognito=`) had three main issues:
1. **Tight render loop** — `checkConversationChange()` fired every 750ms. `conversationData` was cleared to null, `null?.conversationId` returned `undefined`, and `undefined > !== null` is always true.
2. **Missing Length/Cost/Cache UI** — `getTitleAreaAnchor()` requires `[data-testid="chat-menu-trigger"]`, which doesn't exist without a saved conversation.
3. **Wasted polling on init** — `initExtension()` spent 6 seconds polling for a sidebar that doesn't appear in incognito, logging a spurious warning.

**Solution:**
- Added `incognitoConversation` layout with a `titleArea` anchor below `#ut-chat-stat-line`.
- Guarded the conversation change check with `newConversation !== null`.
- Added an early-exit in `initExtension()` for incognito pages to prevent wasted polling.