### PR TITLE
fix: model version lookup with prefix matching

### DIFF
--- a/content-components/content_utils.js
+++ b/content-components/content_utils.js
@@ -203,8 +203,10 @@ async function getCurrentModelVersion(maxWait = 3000) {
 	const modelSelector = await waitForElement(document, SELECTORS.MODEL_PICKER, maxWait);
 	if (!modelSelector) return CONFIG.DEFAULT_MODEL_VERSION;
 	const text = modelSelector.querySelector('.whitespace-nowrap')?.textContent?.trim();
-	if (!text) return CONFIG.DEFAULT_MODEL_VERSION;
-	return CONFIG.MODEL_VERSION_MAP[text.toLowerCase()] || CONFIG.DEFAULT_MODEL_VERSION;
+    if (!text) return CONFIG.DEFAULT_MODEL_VERSION;
+    const normalizedText = text.toLowerCase();
+    const matchedModel = Object.keys(CONFIG.MODEL_VERSION_MAP).find(key => normalizedText.startsWith(key));
+	return matchedModel ? CONFIG.MODEL_VERSION_MAP[matchedModel] : CONFIG.DEFAULT_MODEL_VERSION;
 }
 
 function isMobileView() {


### PR DESCRIPTION
**Problem:** 

`getCurrentModelVersion` returns the default model `"claude-opus-4-7"` if the model picker selector includes `"Extended"` or `"Adaptive"` from either being enabled. 

**Example:**

If extended thinking is enabled for Opus 4.6, `document.querySelector('[data-testid="model-selector-dropdown"]').querySelector('.whitespace-nowrap').textContent` returns `"Opus 4.6 Extended"`.

**Fix:**
Uses `startsWith` matching against `MODEL_VERSION_MAP` keys instead of exact lookup, so suffixes like "Extended" and "Adaptive" don't break the match.