### PR TITLE
fix: mount the sidebar usage section inside the scrollable nav area

### DIFF
--- a/content-components/content_utils.js
+++ b/content-components/content_utils.js
@@ -592,9 +592,18 @@ function getSidebarDesktopAnchor() {
 	const navScroll = sidebarBody.querySelector('.dframe-nav-scroll');
 	if (!navScroll) return null;
 
+	// Mount INSIDE the scroll area, above the recents, rather than as a fixed block above it.
+	// Sitting outside meant our ~220px of bars ate the scroll area's flex basis: on a short
+	// viewport the recents collapsed to a few pixels and our own content overflowed onto the
+	// bottom tray, with no way to scroll any of it back. Inside, everything scrolls together.
+	// shrink-0 keeps the bars at full height instead of being squashed by the flex column.
+	const referenceNode = Array.from(navScroll.children)
+		.find(child => !child.classList.contains('ut-usage-sidebar')) || null;
+
 	return {
-		parent: navScroll.parentElement,
-		referenceNode: navScroll,
+		parent: navScroll,
+		referenceNode,
+		classes: { add: ['shrink-0'] },
 	};
 }
 


### PR DESCRIPTION
## Problem

On short screens the sidebar became unusable. `getSidebarDesktopAnchor` inserted the ~220px usage block as a sibling **above** `.dframe-nav-scroll`, so it competed with the scroll area for the flex column's height.

At `innerHeight: 561` the scroll area collapsed to **12px** (recents entirely gone) while our block overflowed 20px past the column and landed on top of the "Design" products row and the footer — none of it scrollable.

## Fix

Mount the container as the first child **inside** `.dframe-nav-scroll`, so the bars and the recents scroll together.

- `shrink-0` keeps the bars at full height instead of being squashed by the scroll container's flex column (the recents rows do the same).
- The scroll area's `-mx-1 px-1` cancels out against the body's `px-2`, so the block's left edge stays at the same 8px — no horizontal shift.
- The reference node skips our own element, so a re-mount is a no-op rather than an infinite re-insert. Verified: 0 re-inserts over 4s with a MutationObserver.

## Verified in Chrome

| | before | after |
|---|---|---|
| `.dframe-nav-scroll` height @ 561px viewport | 12px | 204px, scrollable |
| usage block | overflows onto the bottom tray | clipped/scrolls with recents |

Checked at 561px and 802px viewports, on `/new` and on a conversation, plus tall-viewport layout unchanged.

## Out of scope

`/code` no longer shows the usage panel at all — its sidebar migrated to the same dframe shell, so the `code` layout's `nav.flex` / `a[href="/code"]` selectors no longer match and the anchor returns null. Pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXzALzdPEhd7tPMkudoFpG