### PR TITLE
fix: restore model detection after claude.ai's picker redesign

### DIFF
--- a/background.js
+++ b/background.js
@@ -781,8 +781,6 @@ async function runAuthoritativePass({ orgId, conversationId, api, tabId }) {
 	// one-shot side effects (lifetime token counter, usage delta log) fire exactly once.
 	const alreadyCounted = !!pendingRequest?.settled;
 
-	const model = pendingRequest?.model || defaultModelForTier(usageData.subscriptionTier);
-
 	const conversationData = await conversation.getInfo(isNewMessage, {
 		toolTokens: pendingRequest?.toolTokens || 0
 	});
@@ -794,19 +792,27 @@ async function runAuthoritativePass({ orgId, conversationId, api, tabId }) {
 
 	// Profile and tool tokens are applied inside getInfo now, so there is exactly one place that
 	// knows how they are priced. Nothing to patch here.
-	conversationData.model = model;
-	await Log('authoritative pass: modelVersion -',
-		'from API:', conversationData.modelVersion,
-		'| from pendingRequest:', pendingRequest?.modelVersion);
+	//
+	// Both model fields are overridden only when the request that triggered this pass actually knows
+	// better. getInfo already derives them from the conversation's own `model`, and the pass also
+	// runs on plain navigation, where there is no pendingRequest at all - assigning the tier default
+	// unconditionally there replaced a correct family (Fable) with a wrong one (Opus), leaving
+	// `model` and `modelVersion` describing different models.
+	await Log('authoritative pass: model -',
+		'from API:', conversationData.model, conversationData.modelVersion,
+		'| from pendingRequest:', pendingRequest?.model, pendingRequest?.modelVersion);
+	if (pendingRequest?.model) {
+		conversationData.model = pendingRequest.model;
+	}
 	if (pendingRequest?.modelVersion) {
 		conversationData.modelVersion = pendingRequest.modelVersion;
 	}
-	await Log('authoritative pass: modelVersion final:', conversationData.modelVersion);
+	await Log('authoritative pass: model final:', conversationData.model, conversationData.modelVersion);
 
 	// If new message: log delta and update total tokens. Once per message, never on a repeat pass.
 	if (isNewMessage && !alreadyCounted && pendingRequest.previousUsage) {
 		const previousUsage = UsageData.fromJSON(pendingRequest.previousUsage);
-		await logUsageDelta(orgId, previousUsage, usageData, conversationData.length, model);
+		await logUsageDelta(orgId, previousUsage, usageData, conversationData.length, conversationData.model);
 
 		// Add message cost to total tracked
 		await tokenStorageManager.addToTotalTokens(conversationData.cost);

--- a/content-components/content_utils.js
+++ b/content-components/content_utils.js
@@ -235,30 +235,59 @@ async function waitForElement(target, selector, maxTime = 1000) {
 	return null;
 }
 
-// subscriptionTier decides the default when the picker can't be read - claude.ai defaults
-// Max to Opus and everyone else to Sonnet. Pass null if the tier isn't known yet.
-async function getCurrentModel(maxWait = 3000, subscriptionTier = null) {
-	const modelSelector = await waitForElement(document, SELECTORS.MODEL_PICKER, maxWait);
-	if (!modelSelector) return defaultModelForTier(subscriptionTier);
-
-	const fullModelName = modelSelector.querySelector('.whitespace-nowrap')?.textContent?.trim();
-	if (!fullModelName) return defaultModelForTier(subscriptionTier);
-
-	const matchedModel = modelFamilyFromVersion(fullModelName);
-	if (matchedModel) return matchedModel;
-
-	await Log("Could not find matching model, returning default")
-	return defaultModelForTier(subscriptionTier);
+// An unreadable picker is a standing condition, not an event: checkModelChange re-reads it every
+// highUpdateFrequency ms off the rAF loop, so logging unconditionally would fill debug_logs with
+// the same line hundreds of times a minute. Warn once per distinct label instead.
+let lastWarnedPickerLabel = null;
+function warnUnreadablePickerOnce(label) {
+	if (label === lastWarnedPickerLabel) return;
+	lastWarnedPickerLabel = label;
+	Log("warn", "Model picker present but no known model in its label:", label);
 }
 
+// The API model id the NEXT message will use, read out of the picker. Returns null when the picker
+// is there but we can't make sense of it - see the fallback comment below.
+//
+// subscriptionTier decides the default when there is no picker at all - claude.ai defaults Max to
+// Opus and everyone else to Sonnet. Pass null if the tier isn't known yet.
 async function getCurrentModelVersion(maxWait = 3000, subscriptionTier = null) {
 	const modelSelector = await waitForElement(document, SELECTORS.MODEL_PICKER, maxWait);
+	// No picker at all (not rendered yet, login screen): nothing to read, and no conversation to
+	// fall back on either, so the tier default is the best guess available.
 	if (!modelSelector) return defaultModelVersionForTier(subscriptionTier);
-	const text = modelSelector.querySelector('.whitespace-nowrap')?.textContent?.trim();
-    if (!text) return defaultModelVersionForTier(subscriptionTier);
-    const normalizedText = text.toLowerCase();
-    const matchedModel = Object.keys(CONFIG.MODEL_VERSION_MAP).find(key => normalizedText.startsWith(key));
-	return matchedModel ? CONFIG.MODEL_VERSION_MAP[matchedModel] : defaultModelVersionForTier(subscriptionTier);
+
+	// Read the BUTTON's own label rather than a descendant styling class. claude.ai's CDS redesign
+	// moved `whitespace-nowrap` from an inner span onto the button itself, and querySelector never
+	// matches the element it is called on - so the old lookup silently returned null and every
+	// conversation was reported as the tier's default model, which killed cache tracking on every
+	// chat not using that model. aria-label is the primary source (semantic, and required for a11y);
+	// textContent is the backup.
+	const label = (modelSelector.getAttribute('aria-label') || modelSelector.textContent || '')
+		.trim().toLowerCase();
+
+	// Longest key first so "opus 4.5" wins over "opus 4" without depending on the insertion order of
+	// MODEL_VERSION_MAP. `includes` rather than `startsWith` because the label carries decoration on
+	// both sides: "Model: " in front, the effort level ("High", "Medium") behind.
+	const matchedModel = Object.keys(CONFIG.MODEL_VERSION_MAP)
+		.sort((a, b) => b.length - a.length)
+		.find(key => label.includes(key));
+	if (matchedModel) return CONFIG.MODEL_VERSION_MAP[matchedModel];
+
+	// Picker is there but unreadable - restyled again, or a model we don't ship a label for yet.
+	// Return null ("unknown") rather than the tier default: null makes ConversationData fall back to
+	// the conversation's own model (isCurrentlyCached and getWeightedFutureCost both treat a missing
+	// override that way), which is right almost always. A confident wrong guess instead disables
+	// cache tracking with no visible symptom - which is exactly how this rotted last time.
+	warnUnreadablePickerOnce(label);
+	return null;
+}
+
+// Model family (Opus/Sonnet/...) for the picker's selection, or null when the version is unknown.
+// Delegates so there is one parser: defaultModelForTier is itself defined as
+// modelFamilyFromVersion(defaultModelVersionForTier(tier)), so the no-picker branch is unchanged.
+async function getCurrentModel(maxWait = 3000, subscriptionTier = null) {
+	const modelVersion = await getCurrentModelVersion(maxWait, subscriptionTier);
+	return modelVersion ? modelFamilyFromVersion(modelVersion) : null;
 }
 
 function isMobileView() {

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Claude Usage Tracker",
-	"version": "5.4.7",
+	"version": "5.4.8",
 	"description": "Helps you track your claude.ai usage caps based on tokens sent.",
 	"author": "lugia19",
 	"browser_specific_settings": {

--- a/manifest_electron.json
+++ b/manifest_electron.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Claude Usage Tracker",
-	"version": "5.4.7",
+	"version": "5.4.8",
 	"description": "Helps you track your claude.ai usage caps based on tokens sent.",
 	"author": "lugia19",
 	"browser_specific_settings": {

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Claude Usage Tracker",
-	"version": "5.4.7",
+	"version": "5.4.8",
 	"description": "Helps you track your claude.ai usage caps based on tokens sent.",
 	"author": "lugia19",
 	"browser_specific_settings": {

--- a/update_patchnotes.txt
+++ b/update_patchnotes.txt
@@ -1,2 +1,1 @@
-Fix for the free tier (may be temporary, as Anthropic seems to be removing usage data from it)
-Inject UI in the scrollable part of the sidebar to fix issues on short screens
+Fixed model detection that broke due to UI changes (fixes caching status)


### PR DESCRIPTION
## What broke

claude.ai migrated the model picker to their CDS design-system button, which now carries `whitespace-nowrap` **on the button itself** instead of on an inner span:

```html
<button data-testid="model-selector-dropdown"
        class="cds-reset … whitespace-nowrap …"
        aria-label="Model: Fable 5 High">
  <span class="truncate">Fable 5 <span class="text-muted">High</span></span>
```

`content_utils.js` did `modelSelector.querySelector('.whitespace-nowrap')`, and `querySelector` never matches the element it is called on — so both picker reads returned `null` and fell through to `defaultModelVersionForTier` / `defaultModelForTier`. Detection was frozen at `claude-opus-5` / `"Opus"` on Max regardless of the picker.

`ConversationData.isCurrentlyCached(v)` requires `this.modelVersion === v`, so the cache indicator only rendered on conversations that happened to use the tier's default model. The backend was never wrong — `CacheV2: Fast path — cache active` fired throughout, with a valid `conversationIsCachedUntil` and `costUsedCache: true`.

Measured A/B on one conversation, cache alive in both rows:

| msg | picker | stored `modelVersion` | detected | `isCurrentlyCached` | UI |
|---|---|---|---|---|---|
| 1 | Opus 5 | `claude-opus-5` | `claude-opus-5` | true | `… \| Cached for: 60m` |
| 2 | Fable 5 | `claude-fable-5` | `claude-opus-5` | **false** | `…` (gone) |

Second symptom, same cause: cost stopped responding to the picker at all (weight pinned to Opus ×5). One chat displayed 192,200 credits where 60,700 was correct.

## The fix

**Read the button's own label.** `aria-label` primarily, `textContent` as backup — no descendant class in the query, so internal restructuring can't break it again. Matching moves from `startsWith` to longest-key-first `includes`, since the label now carries `"Model: "` in front and the effort level (`High`, `Medium`) behind. `getCurrentModel` delegates to `getCurrentModelVersion` so there's a single parser; `defaultModelForTier` is defined as `modelFamilyFromVersion(defaultModelVersionForTier(tier))`, so the no-picker branch is unchanged.

**Fail to `null`, not to the tier default.** The degradation paths already existed and are strictly better: `isCurrentlyCached` treats a missing override as "don't second-guess the conversation", and `getWeightedFutureCost` falls back to `this.model`. A confident wrong guess instead disables cache tracking with no visible symptom — which is exactly how this rotted unnoticed. The tier default is now reserved for the picker being **absent** (pre-render, login screen), where there's no conversation to fall back on. An unreadable picker is a standing condition re-read every 750ms off the rAF loop, so the warning is deduped per distinct label.

**Stop clobbering `conversationData.model`.** That `null` path needs `this.model` to be trustworthy, and it wasn't. `runAuthoritativePass` overwrote the family `getInfo` correctly derived with the tier default whenever there was no `pendingRequest` — i.e. on every navigation-triggered pass — so `model` said `Opus` while `modelVersion` said `claude-fable-5`. Now guarded the same way the `modelVersion` line below it already was.

Investigated and ruled out as more robust sources: `localStorage['default-model']` is stale (reads `claude-opus-5` while a freshly loaded `/new` picker shows Fable), `account_profile` and org account settings carry no model field, the `PUT` fired on a model switch carries only `paprika_mode` and leaves the conversation's `model` untouched, and no `data-*` attribute anywhere holds the model id. The selection is client-only state until `/completion`, so the DOM is unavoidable.

## Verification

In Chrome on the unpacked debug build (confirmed 5.4.6 → 5.4.7 reload):

- Fable conversation shows `Cached for: 60m` again, and survives a hard refresh
- Cost tracks the picker: Fable ×10 = 30,520 ↔ Opus ×5 = 15,420; the indicator correctly drops when the picker diverges from the conversation's model and returns when it matches
- Bug 2: navigation pass delivers `"model": "Fable"` alongside `"modelVersion": "claude-fable-5"`
- Poisoned `aria-label`: display unchanged (degrades to the conversation's model), exactly **1** warning across ~11 poll cycles
- `npx eslint .` clean

No generated-twin rebuild needed — `shared/dataclasses.js` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fe8JKoUZAgYPJcgqXPyj4T