### PR TITLE
refactor: make "unknown model" a real state instead of a confident guess

### DIFF
--- a/background.js
+++ b/background.js
@@ -288,11 +288,12 @@ async function updateAllTabsWithUsage(usageData = null) {
 	}
 }
 
-// A conversation record can lag the message that created it: a freshly created chat comes back
-// from the API with no model at all, so getInfo() falls back to CONFIG.DEFAULT_MODEL_VERSION and
-// mislabels it - reporting Opus for a Sonnet chat, which then reads as a model change and hides
-// the cache indicator. The request body we captured is authoritative, so prefer it while it is
-// fresh. Bounded by time because pending entries now expire rather than being deleted on use.
+// A conversation record can lag the message that created it: a freshly created chat comes back from
+// the API with no model at all. getInfo() no longer papers over that with a tier default - it
+// reports the model as unknown - and isCurrentlyCached refuses to claim a cache hit it cannot
+// verify, so without this the indicator would stay hidden on a brand-new chat. The request body we
+// captured is authoritative, so prefer it while it is fresh. Bounded by time because pending entries
+// now expire rather than being deleted on use.
 const PENDING_MODEL_TRUST_MS = 5 * 60 * 1000;
 
 // pendingRequests is two layers: the outer StoredMap key is the conversation, and each value is a

--- a/bg-components/claude-api.js
+++ b/bg-components/claude-api.js
@@ -1,6 +1,6 @@
 import { CONFIG, RawLog, FORCE_DEBUG, StoredMap, getStorageValue, setStorageValue, getOrgStorageKey } from './utils.js';
 import { tokenCounter, getTextFromContent } from './tokenManagement.js';
-import { UsageData, ConversationData, modelFamilyFromVersion, defaultModelForTier, defaultModelVersionForTier } from '../shared/dataclasses.js';
+import { UsageData, ConversationData, modelFamilyFromVersion } from '../shared/dataclasses.js';
 
 const FEATURE_COSTS = {
 	"enabled_artifacts_attachments": 2200,	// DEPRECATED: Analysis tool
@@ -986,9 +986,13 @@ class ConversationAPI {
 			projectStats?.use_project_knowledge_search       // Project retrieval
 		);
 
-		const subscriptionTier = await this.api.getSubscriptionTier();
-		const conversationModelVersion = conversationData.model || defaultModelVersionForTier(subscriptionTier);
-		const conversationModelType = modelFamilyFromVersion(conversationModelVersion) || defaultModelForTier(subscriptionTier);
+		// Null when the API reports no model at all, which a freshly created conversation does for a
+		// short window. Substituting the tier default here used to mislabel those chats - reporting
+		// Opus for a Sonnet conversation - which read as a model change and hid the cache indicator.
+		// The honest answer is "we don't know yet"; runAuthoritativePass fills it in from the
+		// captured request body when there is one (see applyPendingModel).
+		const conversationModelVersion = conversationData.model || null;
+		const conversationModelType = modelFamilyFromVersion(conversationModelVersion);
 
 		await Log(`Total tokens for conversation ${this.conversationId}: ${lengthTokens} with model ${conversationModelType}`);
 

--- a/content-components/content_utils.js
+++ b/content-components/content_utils.js
@@ -1,5 +1,5 @@
 /* global localize, fmtNum, normalizeLocale, setLocaleOverride,
-   modelFamilyFromVersion, defaultModelForTier, defaultModelVersionForTier */
+   modelFamilyFromVersion, defaultModelVersionForTier, MODEL_UNKNOWN */
 'use strict';
 
 // Constants
@@ -274,20 +274,25 @@ async function getCurrentModelVersion(maxWait = 3000, subscriptionTier = null) {
 	if (matchedModel) return CONFIG.MODEL_VERSION_MAP[matchedModel];
 
 	// Picker is there but unreadable - restyled again, or a model we don't ship a label for yet.
-	// Return null ("unknown") rather than the tier default: null makes ConversationData fall back to
-	// the conversation's own model (isCurrentlyCached and getWeightedFutureCost both treat a missing
-	// override that way), which is right almost always. A confident wrong guess instead disables
-	// cache tracking with no visible symptom - which is exactly how this rotted last time.
+	// MODEL_UNKNOWN, not the tier default and not a bare null: it says "we looked and could not
+	// tell", which isCurrentlyCached treats as a reason to withhold the cache claim rather than as
+	// permission to skip the check. A confident wrong guess instead disables cache tracking with no
+	// visible symptom - which is exactly how this rotted last time.
 	warnUnreadablePickerOnce(label);
-	return null;
+	return MODEL_UNKNOWN;
 }
 
-// Model family (Opus/Sonnet/...) for the picker's selection, or null when the version is unknown.
-// Delegates so there is one parser: defaultModelForTier is itself defined as
-// modelFamilyFromVersion(defaultModelVersionForTier(tier)), so the no-picker branch is unchanged.
+// Model family (Opus/Sonnet/...) for the picker's selection. Delegates so there is one parser.
+//
+// Returns null - not MODEL_UNKNOWN - when the model can't be identified, and that asymmetry with
+// getCurrentModelVersion is deliberate. This value only ever weights a cost estimate, where null
+// makes getWeightedFutureCost fall back to the conversation's own model; handing it MODEL_UNKNOWN
+// would instead land on FALLBACK_MODEL_WEIGHT and price every unknown model as Opus. Estimates may
+// degrade to something plausible, but the cache claim may not - see isCurrentlyCached.
 async function getCurrentModel(maxWait = 3000, subscriptionTier = null) {
 	const modelVersion = await getCurrentModelVersion(maxWait, subscriptionTier);
-	return modelVersion ? modelFamilyFromVersion(modelVersion) : null;
+	if (!modelVersion || modelVersion === MODEL_UNKNOWN) return null;
+	return modelFamilyFromVersion(modelVersion);
 }
 
 function isMobileView() {

--- a/content-components/length_ui.js
+++ b/content-components/length_ui.js
@@ -449,12 +449,18 @@ class LengthUI {
 		}
 	}
 
+	// Compared plainly rather than guarded on truthiness. The old `newModel && ...` form silently
+	// dropped any falsy reading, so a picker that went from readable to unreadable kept reporting
+	// the previous model here until the next renderAll - which assigns the reading directly and so
+	// disagreed with this path. getCurrentModelVersion now always returns something meaningful (a
+	// model id, the tier default when there is no picker, or MODEL_UNKNOWN), so there is no
+	// transient falsy value left to protect against.
 	async checkModelChange() {
 		const tier = this.state.usageData?.subscriptionTier;
 		const newModel = await getCurrentModel(200, tier);
 		const newModelVersion = await getCurrentModelVersion(200, tier);
-		if ((newModel && newModel !== this.state.currentModel) ||
-			(newModelVersion && newModelVersion !== this.state.currentModelVersion)) {
+		if (newModel !== this.state.currentModel ||
+			newModelVersion !== this.state.currentModelVersion) {
 			await Log('LengthUI: Model changed, recalculating displays');
 			this.state.currentModel = newModel;
 			this.state.currentModelVersion = newModelVersion;

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Claude Usage Tracker",
-	"version": "5.4.8",
+	"version": "5.4.9",
 	"description": "Helps you track your claude.ai usage caps based on tokens sent.",
 	"author": "lugia19",
 	"browser_specific_settings": {

--- a/manifest_electron.json
+++ b/manifest_electron.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Claude Usage Tracker",
-	"version": "5.4.8",
+	"version": "5.4.9",
 	"description": "Helps you track your claude.ai usage caps based on tokens sent.",
 	"author": "lugia19",
 	"browser_specific_settings": {

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Claude Usage Tracker",
-	"version": "5.4.8",
+	"version": "5.4.9",
 	"description": "Helps you track your claude.ai usage caps based on tokens sent.",
 	"author": "lugia19",
 	"browser_specific_settings": {

--- a/shared/dataclasses.js
+++ b/shared/dataclasses.js
@@ -12,6 +12,18 @@ export function isPeakHours() {
 	return hour >= 12 && hour < 18;
 }
 
+// "We looked, and we could not tell which model this is" - distinct from "the caller expressed no
+// opinion about the model", which is what a null/absent override means.
+//
+// An explicit sentinel rather than an undefined-vs-null distinction on purpose: conflating those two
+// is exactly the bug this exists to prevent. The picker read as the tier's default model for weeks
+// because an unreadable picker produced a confident wrong answer instead of admitting ignorance, and
+// nothing downstream could tell the difference.
+//
+// It is only ever passed as an argument, never stored on a ConversationData - the conversation's own
+// unknown model is plain null, matching how every other absent field on that class is represented.
+export const MODEL_UNKNOWN = '__model_unknown__';
+
 // Model family (Opus/Sonnet/...) for an API model ID; null if unrecognized.
 export function modelFamilyFromVersion(modelVersion) {
 	const slug = (modelVersion || '').toLowerCase();
@@ -26,6 +38,16 @@ export function defaultModelVersionForTier(subscriptionTier) {
 
 export function defaultModelForTier(subscriptionTier) {
 	return modelFamilyFromVersion(defaultModelVersionForTier(subscriptionTier));
+}
+
+// A missing cap is a standing condition, not an event - getLimitingFactor re-derives it on every
+// usage update - so warn once per tier/limit rather than on every pass.
+const warnedMissingCaps = new Set();
+function warnMissingCapOnce(subscriptionTier, limitKey) {
+	const key = `${subscriptionTier}:${limitKey}`;
+	if (warnedMissingCaps.has(key)) return;
+	warnedMissingCaps.add(key);
+	console.warn(`No ESTIMATED_CAPS entry for ${key} - this limit is excluded from the messages-left estimate`);
 }
 
 export class UsageData {
@@ -75,13 +97,15 @@ export class UsageData {
 			extraUsage = {
 				isEnabled: true,
 				monthlyLimit: spend.limit?.amount_minor ?? spend.cap?.money?.amount_minor ?? 0,
-				usedCredits: spend.used?.amount_minor || 0
+				// `??`, not `||` - a genuine zero spend and a missing `used` object are different
+				// things, and the latter should not quietly render as "$0.00 used".
+				usedCredits: spend.used?.amount_minor ?? 0
 			};
 		} else if (apiResponse.extra_usage?.is_enabled) {
 			extraUsage = {
 				isEnabled: true,
 				monthlyLimit: apiResponse.extra_usage.monthly_limit,
-				usedCredits: apiResponse.extra_usage.used_credits || 0
+				usedCredits: apiResponse.extra_usage.used_credits ?? 0
 			};
 		}
 
@@ -123,13 +147,23 @@ export class UsageData {
 		return limits;
 	}
 
-	// Convert % to estimated tokens remaining for a limit
+	// Convert % to estimated tokens remaining for a limit.
+	//
+	// Returns null for two different reasons, and the caller (getLimitingFactor) is right to skip
+	// either way - but only one of them is normal. "This account has no such limit" is expected;
+	// "we ship no ESTIMATED_CAPS entry for this tier" is a config gap that silently drops the limit
+	// out of the messages-left estimate with nothing to show for it. Warn on that one so a missing
+	// tier stops being invisible - same reasoning as the unreadable-picker warning, and the same
+	// shape as the console.warn for an unrecognised scoped limit above.
 	getEstimatedTokensRemaining(limitKey) {
 		const limit = this.limits[limitKey];
 		if (!limit) return null;
 
 		let cap = CONFIG.ESTIMATED_CAPS?.[this.subscriptionTier]?.[limitKey];
-		if (!cap) return null;
+		if (!cap) {
+			warnMissingCapOnce(this.subscriptionTier, limitKey);
+			return null;
+		}
 
 		// During peak hours, session cap is effectively lower
 		if (limitKey === 'session' && isPeakHours()) {
@@ -297,10 +331,16 @@ export class ConversationData {
 		this.uncachedCost = data.uncachedCost || 0;       // Without caching
 		this.futureCost = data.futureCost || 0; // Estimated cost of future messages
 		this.uncachedFutureCost = data.uncachedFutureCost || 0; // Estimated future cost without caching
-		// Defensive only - the background always populates both before this is rehydrated
-		// from JSON, and it has a subscription tier available to pick a better default.
-		this.modelVersion = data.modelVersion || CONFIG.DEFAULT_MODEL_VERSION;
-		this.model = data.model || modelFamilyFromVersion(this.modelVersion);
+		// null means "the API did not tell us which model this conversation uses" - carried through
+		// rather than papered over with CONFIG.DEFAULT_MODEL_VERSION. Substituting a default here
+		// made a freshly created chat (whose record briefly has no model) claim to be Sonnet, which
+		// then read as a model change and hid the cache indicator; applyPendingModel in the
+		// background exists to fill this in from the authoritative request body.
+		//
+		// `??`, not `||`: toJSON/fromJSON round-trip this field verbatim, so an explicit null has to
+		// survive rehydration instead of being re-defaulted on the content-script side.
+		this.modelVersion = data.modelVersion ?? null;
+		this.model = data.model ?? modelFamilyFromVersion(this.modelVersion);
 
 		// Cache status
 		this.costUsedCache = data.costUsedCache || false;	//Currently unused, since now we show future_cost rather than past cost
@@ -314,10 +354,24 @@ export class ConversationData {
 		this.orgId = data.orgId || null;
 	}
 
-	// Add helper method to check if currently cached
+	// Whether the NEXT message on `currentModelVersion` will hit this conversation's cache.
+	//
+	// This is a promise made to the user, not an estimate, so it is never asserted on a guess: if
+	// either side of the comparison is unknown the answer is no. That is the opposite of how the
+	// cost figures below degrade, and deliberately so - over-reporting a cost is harmless, while
+	// promising a discount that does not exist is not, and a wrong "cached" is invisible.
+	//
+	// `currentModelVersion` has three meanings:
+	//   absent/null    - the caller has no opinion; only cache validity matters
+	//   MODEL_UNKNOWN  - the caller looked and could not tell; refuse to claim
+	//   anything else  - a real model id to compare against
 	isCurrentlyCached(currentModelVersion) {
-		return this.conversationIsCachedUntil && this.conversationIsCachedUntil > Date.now()
-			&& (!currentModelVersion || this.modelVersion === currentModelVersion);
+		if (!this.conversationIsCachedUntil || this.conversationIsCachedUntil <= Date.now()) return false;
+		if (currentModelVersion === MODEL_UNKNOWN) return false;
+		if (!currentModelVersion) return true;
+		// We know what is being sent but not what the cache holds, so we cannot say they match.
+		if (!this.modelVersion) return false;
+		return this.modelVersion === currentModelVersion;
 	}
 
 	// Add method to get time until cache expires


### PR DESCRIPTION
Follow-up to #87, including the Codex P2 that was accepted and deferred there.

## Why

#87's root cause was not really the DOM selector. It was that the failure path **invented a plausible value** — the tier default — instead of admitting ignorance, so the breakage stayed invisible for weeks. Auditing for that same move turned up several more instances.

The codebase already has a good representation for "we don't know": `null`, which the UI honestly renders as `N/A` (`length_ui.js:184-190`). These sites bypassed it.

**The governing distinction**, applied deliberately in opposite directions:

| | Degrades to | Why |
|---|---|---|
| A cost **estimate** | something plausible | `MODEL_WEIGHTS[model] ?? FALLBACK_MODEL_WEIGHT` already does this well — *"erring high is the safe direction"* |
| A **claim** to the user (*"cached"*) | refusal | over-reporting a cost is harmless; promising a discount that doesn't exist is not, and a wrong "cached" is invisible |

## What changed

**`MODEL_UNKNOWN` sentinel** — explicit, rather than an `undefined`-vs-`null` distinction, because conflating those two is precisely the bug being removed. `isCurrentlyCached` now returns `false` when *either* side of the comparison is unknown, so an unreadable picker withholds the indicator instead of skipping the check and asserting a hit.

**Stopped inventing a model version.** `ConversationData` no longer substitutes `CONFIG.DEFAULT_MODEL_VERSION`, and `getInfo` no longer substitutes the tier default *before* constructing it — fixing only one would have been a no-op. A freshly created chat briefly has no model, and inventing one made it claim to be Sonnet, read as a model change, and hide the cache indicator. `applyPendingModel` already fills that in from the authoritative request body; it's now load-bearing for a *different* reason, so its rationale comment is rewritten rather than removed. `??` not `||`, since `toJSON`/`fromJSON` round-trip the field.

**`checkModelChange` compared on truthiness** (the deferred Codex P2), silently dropping any falsy reading — so a picker going readable → unreadable kept reporting the previous model until the next `renderAll`, which assigns the reading directly and therefore disagreed with the poller. Compared plainly now.

**`getEstimatedTokensRemaining` returned `null` for two different reasons** — "no such limit" and "no `ESTIMATED_CAPS` entry for this tier". The caller is right to skip either way, so the return stays `null`; but the second is a config gap that silently drops a limit out of the messages-left estimate, so it now warns once per `tier:limit`.

**Two adjacent lines disagreed on `??` vs `||`** in the extra-usage literal, so a missing `used` reported $0.00 spent.

## Deliberately not changed

- `getInfo`'s synthetic ConversationData fallback — a hard-won anti-freakout measure, rare and transient by design.
- The `|| 0` numeric defaults, which are what make that fallback render as zeros.
- `getWeightedCost(modelOverride)` has no callers anywhere; noted, left alone rather than removed as drive-by scope.

## Verification

In Chrome on the unpacked debug build (reload confirmed 5.4.7 → 5.4.8), plus the **shipped generated twin** exercised directly under node:

- No regression on #87 — Fable conversation still shows `Cached for: 27m` at Fable weight
- Unreadable picker now **suppresses** the indicator (the intended reversal of #87's behaviour), while cost stays at the conversation's model: **370** = 37 × Fable 10, *not* 185 = 37 × `FALLBACK_MODEL_WEIGHT` 5
- That takes effect within one 750ms poll cycle, with no `renderAll` — the F4 fix
- A brand-new chat still shows `Cached for: 60m`, so `applyPendingModel` covers the now-`null` version
- Full `isCurrentlyCached` truth table passes; `null` survives `toJSON`→`fromJSON`; an absent `modelVersion` is `null`, not Sonnet
- The cap warning fires **once** across 20 passes
- `npx eslint .` clean

Note the generated twins are gitignored (`.gitignore:15,19`) and rebuilt by `build.bat`, so there's nothing to commit for them — but `node scripts/build-dataclasses.js` is required locally before the debug build reflects this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fe8JKoUZAgYPJcgqXPyj4T