### PR TITLE
fix: re-anchor the chat usage bar after claude.ai's composer redesign

### DIFF
--- a/content-components/content_utils.js
+++ b/content-components/content_utils.js
@@ -658,12 +658,15 @@ function getChatAreaRegularAnchor() {
 		};
 	}
 
-	// Pre-redesign composer: the picker sits in a full-width flex toolbar row.
+	// Pre-redesign composer: the picker sits in a full-width flex toolbar row. A real toolbar row
+	// sits beside the input, never around it — so a match that contains the input is the redesign's
+	// failure mode (the selector walking up to the whole page column), and mounting nothing beats
+	// mounting the line at the bottom of the page.
 	const modelSelector = document.querySelector(SELECTORS.MODEL_SELECTOR);
 	if (!modelSelector) return null;
 
 	const toolbarRow = modelSelector.closest('.flex.w-full.items-center');
-	if (!toolbarRow) return null;
+	if (!toolbarRow || (chatInput && toolbarRow.contains(chatInput))) return null;
 
 	return {
 		insertAfter: toolbarRow,

--- a/content-components/content_utils.js
+++ b/content-components/content_utils.js
@@ -642,6 +642,23 @@ function getSidebarDesktopAnchor() {
 }
 
 function getChatAreaRegularAnchor() {
+	// Redesigned composer (2026-08): a rounded bg-surface-3 box whose single flow child holds the
+	// input, with the controls either absolutely positioned inside that child (home page) or moved
+	// out to a footer row below the box entirely (conversation view). Neither the picker nor a
+	// full-width toolbar row is a reliable anchor any more — the old `.flex.w-full.items-center`
+	// closest() from the picker walks past the box and false-matches the whole page column,
+	// stranding the stat line at the bottom of the page. Resolve from the input instead and sit
+	// after the flow child, which stacks the line inside the box beneath the input in both views.
+	const chatInput = document.querySelector('[data-testid="chat-input"]');
+	const composerFlowChild = chatInput?.closest('.bg-surface-3 > .relative.w-full.min-w-0');
+	if (composerFlowChild) {
+		return {
+			insertAfter: composerFlowChild,
+			styles: { paddingLeft: '6px', paddingRight: '', paddingBottom: '' },
+		};
+	}
+
+	// Pre-redesign composer: the picker sits in a full-width flex toolbar row.
 	const modelSelector = document.querySelector(SELECTORS.MODEL_SELECTOR);
 	if (!modelSelector) return null;
 


### PR DESCRIPTION
## Summary
claude.ai redesigned the composer: it is now a rounded `bg-surface-3` box whose single flow child holds the input. On the home page the controls (picker, mic) are absolutely positioned inside that child; in the conversation view the model picker moved out of the box entirely, into the disclaimer footer row below it.

The chat-area anchor resolved from the picker via `closest('.flex.w-full.items-center')`, which now walks past the composer and false-matches the whole page column (`mx-auto ... w-full ... flex h-full flex-col items-center`). Result: the stat line rendered full-width at the very bottom of the page on the home view, and didn't mount at all in the conversation view.

## Fix
`getChatAreaRegularAnchor()` now resolves from `[data-testid="chat-input"]` and inserts after `.bg-surface-3 > .relative.w-full.min-w-0`, stacking the line inside the composer box beneath the input — this shape is shared by both the home and conversation variants. The old picker → toolbar-row path is kept as a fallback for the pre-redesign layout.

## Testing
Verified live in Chrome (debug build) on both `/new` and a conversation page: stat line renders inside the composer with session %, progress bar + weekly marker, reset timer, and messages-left; survives the periodic re-mount loop. Title-area and sidebar UIs unaffected. `npx eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8vn8qVP2r8c7dgXTf8kjg