### PR TITLE
fix: treat the effort level as part of the prompt cache key

### DIFF
--- a/background.js
+++ b/background.js
@@ -612,6 +612,13 @@ async function reportStreamCompletion(message, sender, orgId) {
 	provisional.conversationIsCachedUntil = Date.now() + CONFIG.TOKEN_CACHING_DURATION_MS;
 	provisional.costUsedCache = true;
 	provisional.lastMessageTimestamp = Date.now();
+	// Names the turn this estimate describes, so the authoritative pass that follows recognises it
+	// as the same message rather than a new one - see ConversationData.lastMessageUuid. Straight
+	// from the stream, which reports the uuid the tree will come back with. A synthetic key is a
+	// timestamp wearing a uuid's clothes and would compare unequal to the real one anyway, so it is
+	// dropped rather than passed off as an identity.
+	provisional.lastMessageUuid = message.assistantUuid ||
+		(pending.turnUuid && !pending.turnUuid.startsWith(SYNTHETIC_TURN_PREFIX) ? pending.turnUuid : null);
 	// isCurrentlyCached() compares modelVersion against the picker, so a stale one hides the cache
 	// indicator. pendingRequests took this from the request body, which is authoritative.
 	provisional.model = pending.model || provisional.model;

--- a/bg-components/claude-api.js
+++ b/bg-components/claude-api.js
@@ -1049,6 +1049,7 @@ class ConversationAPI {
 			uncachedFutureCost: uncachedFutureCost,
 			model: conversationModelType,
 			modelVersion: conversationModelVersion,
+			lastMessageUuid: conversationData.current_leaf_message_uuid || null,
 			costUsedCache: conversationIsCached,
 			conversationIsCachedUntil: cachedUntil,
 			projectUuid: conversationData.project_uuid,

--- a/content-components/content_utils.js
+++ b/content-components/content_utils.js
@@ -282,6 +282,37 @@ async function getCurrentModelVersion(maxWait = 3000, subscriptionTier = null) {
 	return MODEL_UNKNOWN;
 }
 
+// The effort/thinking selection shown after the model in the picker: "Model: Opus 5 · High".
+//
+// Returned as the RAW label, lowercased, and NOT mapped to an API value - deliberately. claude.ai
+// renders these through react-intl (Low/Medium/High/Extra/Max on models with an effort ladder,
+// thinking-mode wording like "Extended" on those without), so the visible word tracks the account
+// language while the API values do not - and they don't line up anyway: "Extra" is `xhigh` in the
+// request body. Mapping label -> API value would mean shipping claude.ai's translations of five
+// strings across nine locales and keeping them in sync forever.
+//
+// We never need the value itself, only whether it CHANGED since the cache was written, and both
+// sides of that comparison are taken from this same string - see isCurrentlyCached. The background
+// can't supply it either: switching effort inside a conversation fires no request at all, and the
+// choice is ephemeral React state that reverts to the conversation's own effort on reload. That
+// reversion is what makes the reading at data-arrival time a valid baseline.
+//
+// aria-label only. textContent renders as "Opus 5 High" with no separator, so there is nothing to
+// split on there. null means "not observed" - no picker, no label, or a model with no selector at
+// all - which isCurrentlyCached treats as no opinion rather than as a change.
+async function getCurrentEffortLabel(maxWait = 3000) {
+	const modelSelector = await waitForElement(document, SELECTORS.MODEL_PICKER, maxWait);
+	if (!modelSelector) return null;
+
+	const label = modelSelector.getAttribute('aria-label');
+	if (!label) return null;
+
+	const separator = label.indexOf('·');
+	if (separator === -1) return null;
+
+	return label.slice(separator + 1).trim().toLowerCase() || null;
+}
+
 // Model family (Opus/Sonnet/...) for the picker's selection. Delegates so there is one parser.
 //
 // Returns null - not MODEL_UNKNOWN - when the model can't be identified, and that asymmetry with

--- a/content-components/length_ui.js
+++ b/content-components/length_ui.js
@@ -421,8 +421,11 @@ class LengthUI {
 	// the user may have changed in that window, and since nothing follows the pass, the wrong
 	// baseline then stuck for good.
 	//
-	// Falling back to carry-forward when either uuid is missing is the safe direction: it can only
-	// hold a stale "not cached" until the next update, never invent a cache hit that isn't there.
+	// So the baseline is re-read only for a turn we can POSITIVELY identify as a different one:
+	// both uuids present and unequal. Anything short of that - either side missing - carries the
+	// old baseline forward, which is the safe direction: it can only hold a stale "not cached"
+	// until the next update, never invent a cache hit that isn't there. A missing uuid means the
+	// stream didn't report one, which onBeforeRequestHandler already warns about loudly.
 	//
 	// Left null when the picker isn't up yet; checkModelChange adopts the first real reading rather
 	// than treating it as a change, since the user can't have switched a control that isn't there.
@@ -431,7 +434,9 @@ class LengthUI {
 		if (!conversationData) return;
 
 		const sameConversation = previous && previous.conversationId === conversationData.conversationId;
-		if (sameConversation && previous.lastMessageUuid === conversationData.lastMessageUuid) {
+		const newTurn = previous?.lastMessageUuid && conversationData.lastMessageUuid &&
+			previous.lastMessageUuid !== conversationData.lastMessageUuid;
+		if (sameConversation && !newTurn) {
 			conversationData.effortLabel = previous.effortLabel;
 			return;
 		}

--- a/content-components/length_ui.js
+++ b/content-components/length_ui.js
@@ -414,9 +414,15 @@ class LengthUI {
 	//     user has selected but not yet sent. Re-reading it there would quietly adopt the pending
 	//     change as the baseline and put the cache indicator back on. Carry the old one forward.
 	//
-	// `lastMessageTimestamp` is the discriminator, compared for inequality rather than growth: the
-	// authoritative pass reports the assistant message's real created_at, which lands slightly
-	// BEHIND the provisional's Date.now(), and a branch switch can move it backwards outright.
+	// `lastMessageUuid` is the discriminator, NOT the timestamp. A message produces two updates -
+	// the provisional estimate off the completion stream, then the authoritative pass ~1s later -
+	// and their timestamps differ (Date.now() vs the assistant message's real created_at) even
+	// though they describe the same turn. Keying on the timestamp made the pass re-read a picker
+	// the user may have changed in that window, and since nothing follows the pass, the wrong
+	// baseline then stuck for good.
+	//
+	// Falling back to carry-forward when either uuid is missing is the safe direction: it can only
+	// hold a stale "not cached" until the next update, never invent a cache hit that isn't there.
 	//
 	// Left null when the picker isn't up yet; checkModelChange adopts the first real reading rather
 	// than treating it as a change, since the user can't have switched a control that isn't there.
@@ -425,7 +431,7 @@ class LengthUI {
 		if (!conversationData) return;
 
 		const sameConversation = previous && previous.conversationId === conversationData.conversationId;
-		if (sameConversation && previous.lastMessageTimestamp === conversationData.lastMessageTimestamp) {
+		if (sameConversation && previous.lastMessageUuid === conversationData.lastMessageUuid) {
 			conversationData.effortLabel = previous.effortLabel;
 			return;
 		}

--- a/content-components/length_ui.js
+++ b/content-components/length_ui.js
@@ -1,6 +1,6 @@
 /* global CONFIG, Log, setupTooltip, getTooltipPortal, getResetTimeHTML, sleep, sendBackgroundMessage, getActiveOrgId,
    isMobileView, isCodePage, UsageData, ConversationData, getConversationId, getCurrentModel,
-   getCurrentModelVersion, RED_WARNING, BLUE_HIGHLIGHT, SUCCESS_GREEN, SELECTORS,
+   getCurrentModelVersion, getCurrentEffortLabel, RED_WARNING, BLUE_HIGHLIGHT, SUCCESS_GREEN, SELECTORS,
    LayoutManager, mountToAnchor, localize, fmtNum, onSsePartialUsage, shouldApplySseSession */
 'use strict';
 
@@ -13,6 +13,7 @@ class LengthUI {
 			conversationData: null,
 			currentModel: null,
 			currentModelVersion: null,
+			currentEffortLabel: null,
 			nextMessageCost: null,
 			cachedUntilTimestamp: null,
 		};
@@ -80,6 +81,7 @@ class LengthUI {
 			if (!this.pendingUpdates.conversation.conversationId || !currentConvoId ||
 				this.pendingUpdates.conversation.conversationId === currentConvoId) {
 				this.state.conversationData = ConversationData.fromJSON(this.pendingUpdates.conversation);
+				await this.syncEffortBaseline(null);
 				await this.renderAll();
 			}
 			this.pendingUpdates.conversation = null;
@@ -171,15 +173,19 @@ class LengthUI {
 		const tier = this.state.usageData?.subscriptionTier;
 		this.state.currentModel = await getCurrentModel(200, tier);
 		this.state.currentModelVersion = await getCurrentModelVersion(200, tier);
+		this.state.currentEffortLabel = await getCurrentEffortLabel(200);
 		await Log('LengthUI: renderAll - detected:', this.state.currentModelVersion,
 			'| stored on conversation:', this.state.conversationData?.modelVersion,
-			'| isCurrentlyCached:', this.state.conversationData?.isCurrentlyCached(this.state.currentModelVersion));
+			'| effort now:', this.state.currentEffortLabel,
+			'| effort when cached:', this.state.conversationData?.effortLabel,
+			'| isCurrentlyCached:', this.state.conversationData?.isCurrentlyCached(
+				this.state.currentModelVersion, this.state.currentEffortLabel));
 		this.renderCostAndLength();
 		this.renderEstimate();
 	}
 
 	renderCostAndLength() {
-		const { conversationData, currentModel, currentModelVersion } = this.state;
+		const { conversationData, currentModel, currentModelVersion, currentEffortLabel } = this.state;
 		const { length, cost, cached, container } = this.elements.titleArea;
 
 		if (!conversationData) {
@@ -202,11 +208,11 @@ class LengthUI {
 			: baseTooltip;
 
 		// Cost
-		const weightedCost = conversationData.getWeightedFutureCost(currentModel, currentModelVersion);
+		const weightedCost = conversationData.getWeightedFutureCost(currentModel, currentModelVersion, currentEffortLabel);
 		this.state.nextMessageCost = weightedCost;
 
 		let costColor;
-		if (conversationData.isCurrentlyCached(currentModelVersion)) {
+		if (conversationData.isCurrentlyCached(currentModelVersion, currentEffortLabel)) {
 			costColor = SUCCESS_GREEN;
 		} else {
 			costColor = conversationData.isExpensive() ? RED_WARNING : BLUE_HIGHLIGHT;
@@ -216,14 +222,14 @@ class LengthUI {
 		const { usageData } = this.state;
 
 		if (usageData?.isSpendingCredits(currentModel)) {
-			const dollars = this.extraUsageDollars(conversationData, currentModel, currentModelVersion);
+			const dollars = this.extraUsageDollars(conversationData, currentModel, currentModelVersion, currentEffortLabel);
 			cost.innerHTML = `${localize('length.cost')}: <span style="color: ${costColor}">$${dollars.toFixed(2)}</span>`;
 		} else {
 			cost.innerHTML = `${localize('length.cost')}: <span style="color: ${costColor}">${fmtNum(weightedCost)}</span> ${localize('common.unit_credits')}`;
 		}
 
 		// Cached
-		if (conversationData.isCurrentlyCached(currentModelVersion)) {
+		if (conversationData.isCurrentlyCached(currentModelVersion, currentEffortLabel)) {
 			this.state.cachedUntilTimestamp = conversationData.conversationIsCachedUntil;
 			const timeInfo = conversationData.getTimeUntilCacheExpires();
 			cached.innerHTML = `${localize('length.cached_prefix')} <span class="ut-cached-time" style="color: ${SUCCESS_GREEN}">${localize('time.m', { m: timeInfo.minutes })}</span>`;
@@ -239,9 +245,9 @@ class LengthUI {
 	// During extra usage, cache reads cost 10% of input (not free), so interpolate between the
 	// cached (free) and uncached (full price) costs. This is technically not entirely accurate,
 	// but it's accurate enough and doesn't require reworking half the codebase.
-	extraUsageDollars(conversationData, currentModel, currentModelVersion) {
+	extraUsageDollars(conversationData, currentModel, currentModelVersion, currentEffortLabel) {
 		const weight = CONFIG.MODEL_WEIGHTS[currentModel] ?? CONFIG.FALLBACK_MODEL_WEIGHT;
-		const baseFutureCost = conversationData.isCurrentlyCached(currentModelVersion) ? conversationData.futureCost : conversationData.uncachedFutureCost;
+		const baseFutureCost = conversationData.isCurrentlyCached(currentModelVersion, currentEffortLabel) ? conversationData.futureCost : conversationData.uncachedFutureCost;
 		const interpolatedFutureCost = baseFutureCost +
 			CONFIG.EXTRA_USAGE_CACHING_MULTIPLIER * (conversationData.uncachedFutureCost - baseFutureCost);
 		return Math.round(interpolatedFutureCost * weight) / 1_000_000;
@@ -301,7 +307,7 @@ class LengthUI {
 			return;
 		}
 
-		const { usageData, conversationData, currentModel, currentModelVersion } = this.state;
+		const { usageData, conversationData, currentModel, currentModelVersion, currentEffortLabel } = this.state;
 
 		// No limits reported at all (the free plan) - there is nothing to divide the cost into, and
 		// a lone "Messages left: N/A" beside the hidden usage bar reads as breakage. Drop it.
@@ -317,7 +323,7 @@ class LengthUI {
 			return;
 		}
 
-		const messageCost = conversationData.getWeightedFutureCost(currentModel, currentModelVersion);
+		const messageCost = conversationData.getWeightedFutureCost(currentModel, currentModelVersion, currentEffortLabel);
 		const limiting = usageData.getLimitingFactor(messageCost);
 
 		// Estimate from dollars when credits are what's actually being spent — either the regular
@@ -325,7 +331,7 @@ class LengthUI {
 		// healthy plan limit the message will never consume).
 		const spendingCredits = usageData.isSpendingCredits(currentModel);
 		if ((spendingCredits || !limiting || limiting.messagesLeft <= 0) && usageData.hasExtraUsage()) {
-			const costPerMessageDollars = this.extraUsageDollars(conversationData, currentModel, currentModelVersion);
+			const costPerMessageDollars = this.extraUsageDollars(conversationData, currentModel, currentModelVersion, currentEffortLabel);
 
 			if (costPerMessageDollars > 0) {
 				const remainingDollars = usageData.getExtraUsageRemaining() / 100;
@@ -392,8 +398,39 @@ class LengthUI {
 			return;
 		}
 
+		const previous = this.state.conversationData;
 		this.state.conversationData = ConversationData.fromJSON(conversationDataJSON);
-		this.renderAll();
+		this.syncEffortBaseline(previous).then(() => this.renderAll());
+	}
+
+	// Keeps `conversationData.effortLabel` - the effort the prompt cache was written with - current.
+	// The background can't supply it (see getCurrentEffortLabel), so it is read off the picker here,
+	// and WHICH updates it is read on is the whole correctness argument:
+	//
+	//   - the conversation moved on (new conversation, or a message settled): the picker is showing
+	//     the effort that message was sent with, which is exactly what the new cache holds. Stamp it.
+	//   - the same conversation state came round again (a usage window expired and usage_ui asked
+	//     for a refresh, a cache-hit reply to requestData): the picker may be showing an effort the
+	//     user has selected but not yet sent. Re-reading it there would quietly adopt the pending
+	//     change as the baseline and put the cache indicator back on. Carry the old one forward.
+	//
+	// `lastMessageTimestamp` is the discriminator, compared for inequality rather than growth: the
+	// authoritative pass reports the assistant message's real created_at, which lands slightly
+	// BEHIND the provisional's Date.now(), and a branch switch can move it backwards outright.
+	//
+	// Left null when the picker isn't up yet; checkModelChange adopts the first real reading rather
+	// than treating it as a change, since the user can't have switched a control that isn't there.
+	async syncEffortBaseline(previous) {
+		const conversationData = this.state.conversationData;
+		if (!conversationData) return;
+
+		const sameConversation = previous && previous.conversationId === conversationData.conversationId;
+		if (sameConversation && previous.lastMessageTimestamp === conversationData.lastMessageTimestamp) {
+			conversationData.effortLabel = previous.effortLabel;
+			return;
+		}
+
+		conversationData.effortLabel = await getCurrentEffortLabel(200);
 	}
 
 	// ========== UPDATE LOOP ==========
@@ -459,11 +496,22 @@ class LengthUI {
 		const tier = this.state.usageData?.subscriptionTier;
 		const newModel = await getCurrentModel(200, tier);
 		const newModelVersion = await getCurrentModelVersion(200, tier);
+		const newEffortLabel = await getCurrentEffortLabel(200);
+
+		// Late-mounting picker: adopt the first reading as the baseline instead of reporting it as
+		// a change. Only ever fills a null - once stamped, the baseline moves on the next update.
+		const conversationData = this.state.conversationData;
+		if (conversationData && !conversationData.effortLabel && newEffortLabel) {
+			conversationData.effortLabel = newEffortLabel;
+		}
+
 		if (newModel !== this.state.currentModel ||
-			newModelVersion !== this.state.currentModelVersion) {
-			await Log('LengthUI: Model changed, recalculating displays');
+			newModelVersion !== this.state.currentModelVersion ||
+			newEffortLabel !== this.state.currentEffortLabel) {
+			await Log('LengthUI: Model/effort changed, recalculating displays');
 			this.state.currentModel = newModel;
 			this.state.currentModelVersion = newModelVersion;
+			this.state.currentEffortLabel = newEffortLabel;
 			if (this.state.conversationData) {
 				this.renderCostAndLength();
 				this.renderEstimate();

--- a/shared/dataclasses.js
+++ b/shared/dataclasses.js
@@ -342,6 +342,13 @@ export class ConversationData {
 		this.modelVersion = data.modelVersion ?? null;
 		this.model = data.model ?? modelFamilyFromVersion(this.modelVersion);
 
+		// The picker's effort/thinking label as it read when this data was built - the second half
+		// of the cache key, alongside modelVersion. Only the content script can fill this in (the
+		// value lives nowhere the background can see: changing effort inside a conversation fires
+		// no request at all, and the picker's own wording is localized), so it stays null here and
+		// is stamped on arrival. See getCurrentEffortLabel in content_utils.js.
+		this.effortLabel = data.effortLabel ?? null;
+
 		// Cache status
 		this.costUsedCache = data.costUsedCache || false;	//Currently unused, since now we show future_cost rather than past cost
 		this.conversationIsCachedUntil = data.conversationIsCachedUntil || null;
@@ -365,8 +372,20 @@ export class ConversationData {
 	//   absent/null    - the caller has no opinion; only cache validity matters
 	//   MODEL_UNKNOWN  - the caller looked and could not tell; refuse to claim
 	//   anything else  - a real model id to compare against
-	isCurrentlyCached(currentModelVersion) {
+	//
+	// `currentEffortLabel` is the picker's effort/thinking label right now, to be compared against
+	// the one stamped on this data. Absent/null means the caller has no opinion.
+	isCurrentlyCached(currentModelVersion, currentEffortLabel) {
 		if (!this.conversationIsCachedUntil || this.conversationIsCachedUntil <= Date.now()) return false;
+		// Effort is part of the prompt the same way the model is, so changing it misses the cache
+		// just as hard. Checked first because it is independent of the model comparison below and
+		// applies even when the caller has no opinion on the model.
+		//
+		// Asymmetric with the model check on purpose: this only refuses when BOTH sides are known
+		// and differ. An unreadable picker already surfaces as MODEL_UNKNOWN below, so there is no
+		// case where the effort is the only thing we failed to read - and a null on either side
+		// here means "not observed", which is not evidence of a change.
+		if (this.effortLabel && currentEffortLabel && this.effortLabel !== currentEffortLabel) return false;
 		if (currentModelVersion === MODEL_UNKNOWN) return false;
 		if (!currentModelVersion) return true;
 		// We know what is being sent but not what the cache holds, so we cannot say they match.
@@ -398,11 +417,11 @@ export class ConversationData {
 		return Math.round(this.cost * weight);
 	}
 
-	getWeightedFutureCost(modelOverride, modelVersionOverride) {
+	getWeightedFutureCost(modelOverride, modelVersionOverride, effortLabelOverride) {
 		let model = this.model;
 		if (modelOverride) model = modelOverride;
 		const weight = CONFIG.MODEL_WEIGHTS[model] ?? CONFIG.FALLBACK_MODEL_WEIGHT;
-		const baseCost = this.isCurrentlyCached(modelVersionOverride) ? this.futureCost : this.uncachedFutureCost;
+		const baseCost = this.isCurrentlyCached(modelVersionOverride, effortLabelOverride) ? this.futureCost : this.uncachedFutureCost;
 		return Math.round(baseCost * weight);
 	}
 
@@ -427,6 +446,7 @@ export class ConversationData {
 			uncachedFutureCost: this.uncachedFutureCost,
 			model: this.model,
 			modelVersion: this.modelVersion,
+			effortLabel: this.effortLabel,
 			costUsedCache: this.costUsedCache,
 			conversationIsCachedUntil: this.conversationIsCachedUntil,
 			projectUuid: this.projectUuid,

--- a/shared/dataclasses.js
+++ b/shared/dataclasses.js
@@ -342,6 +342,15 @@ export class ConversationData {
 		this.modelVersion = data.modelVersion ?? null;
 		this.model = data.model ?? modelFamilyFromVersion(this.modelVersion);
 
+		// Identifies the turn this data describes: the uuid claude.ai pre-generates for the
+		// assistant message, reported by the completion body, the SSE stream and the tree alike
+		// (see the pendingRequests comment in background.js). Both the provisional estimate and the
+		// authoritative pass that follows it name the SAME turn, which is what lets the content
+		// script tell "the conversation moved on" apart from "the same message settled" - their
+		// timestamps can't, since the provisional stamps Date.now() and the pass reports the
+		// assistant message's real created_at.
+		this.lastMessageUuid = data.lastMessageUuid ?? null;
+
 		// The picker's effort/thinking label as it read when this data was built - the second half
 		// of the cache key, alongside modelVersion. Only the content script can fill this in (the
 		// value lives nowhere the background can see: changing effort inside a conversation fires
@@ -446,6 +455,7 @@ export class ConversationData {
 			uncachedFutureCost: this.uncachedFutureCost,
 			model: this.model,
 			modelVersion: this.modelVersion,
+			lastMessageUuid: this.lastMessageUuid,
 			effortLabel: this.effortLabel,
 			costUsedCache: this.costUsedCache,
 			conversationIsCachedUntil: this.conversationIsCachedUntil,


### PR DESCRIPTION
Reported: changing the effort level also invalidates the prompt cache, but the extension kept showing the "Cached for" pill and priced the next message at the cached rate.

## Why this isn't just `modelVersion` with another field

Two findings from checking the live site, both of which constrain the design:

- **Changing effort inside a conversation fires no network request at all.** It's ephemeral React state that reverts to the conversation's persisted `settings.effort_level` on reload. Only the `/new` composer persists a value (`PATCH /model_selector_state/chat`), and that global value does *not* override a conversation's own effort when you open it. So the background can never see a pending change — the picker is the only source.
- **The picker's label can't be mapped to an API value.** It's react-intl localized, and doesn't share the API vocabulary anyway: "Extra" is `xhigh`. Mapping label → value would mean shipping claude.ai's translations of five strings across nine locales and keeping them in sync forever.

So both sides of the comparison come from that same DOM string. The value itself is never needed — only whether it changed.

## Changes

- `content_utils.js` — `getCurrentEffortLabel()` parses the suffix after the `�` out of the picker's aria-label (`Model: Fable 5 � High`). `textContent` renders without a separator, so aria-label is the only parse. `null` when there's nothing to read, or on a model with no selector.
- `shared/dataclasses.js` — `ConversationData.effortLabel` holds the reading taken when the data was built; `isCurrentlyCached()` / `getWeightedFutureCost()` take the current one. It only refuses when **both** sides are known and differ — an unreadable picker already surfaces as `MODEL_UNKNOWN`, so a null here means "not observed", not "changed".
- `length_ui.js` — `syncEffortBaseline()` re-stamps the baseline only when the conversation actually moved on (new conversation, or `lastMessageTimestamp` changed). `usage_ui` fires `requestData` whenever a usage window expires, and re-reading the picker there would quietly adopt a selected-but-unsent effort as the baseline and put the indicator back on. Compared for inequality rather than growth: the authoritative pass reports the assistant message's real `created_at`, which lands slightly behind the provisional's `Date.now()`.

`ui_dataclasses.js` regenerated. `npx eslint .` clean.

## Verification

Dataclass logic, 9/9: changed/unchanged effort, missing reading on either side, model-vs-effort precedence, cache expiry, cost switching to the uncached figure, JSON round-trip. Parser checked against the live picker for all five levels (`low/medium/high/extra/max`).

End-to-end in Chrome on a cached conversation:

| Picker | Display |
|---|---|
| Fable 5 � High | Cost: 50 credits \| Cached for: 45m — Messages left: 664000.0 |
| Fable 5 � Low | Cost: 80 credits, no pill — Messages left: 415000.0 |
| back to High | Cost: 50 credits \| Cached for: 45m — restored |

Also confirmed it survives a conversation switch and back, and that a reload reverts the picker to the conversation's own effort — the invariant the baseline rests on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZLP5mNBxMHx39d6CFXYC2
