### PR TITLE
feat: map Fable 5.1 to claude-fable-5-1

### DIFF
--- a/bg-components/utils.js
+++ b/bg-components/utils.js
@@ -20,6 +20,7 @@ const CONFIG = {
 		// DOM labels (lowercased) → API model IDs.
 		// Matched with startsWith() in insertion order, so a longer label must come above
 		// any shorter label that prefixes it ("opus 5.1" above "opus 5").
+		"fable 5.1": "claude-fable-5-1",
 		"fable 5": "claude-fable-5",
 		"opus 5": "claude-opus-5",
 		"sonnet 5": "claude-sonnet-5",


### PR DESCRIPTION
## What

Adds `"fable 5.1": "claude-fable-5-1"` to `CONFIG.MODEL_VERSION_MAP`, above the `"fable 5"` entry.

## Why

The picker's `aria-label` reads `Model: Fable 5.1 · High`, but the map only knew `fable 5`, so the label resolved to `claude-fable-5`. Conversations on Fable 5.1 report `claude-fable-5-1` in their own record, so the two sides of `isCurrentlyCached` never matched and the cache indicator was suppressed on every Fable 5.1 chat.

Placed above `"fable 5"` so the longer label wins under either matching rule — `content_utils.js` sorts keys longest-first, and the map's own comment documents insertion order.

Nothing else was needed: `modelFamilyFromVersion` matches the `fable` substring, so the `Fable` weight, the `fableWeekly` limit key and all nine locales' labels already cover 5.1.

## Verification

Slug confirmed against the live account (`chat_conversations` reports `claude-fable-5-1`), and the picker label read straight off the DOM.

Loaded `debug\chrome`, reloaded the extension, opened a `claude-fable-5-1` conversation: the header renders `Length*: 276,495 tokens | Cost: 51,300 credits | Cached for: 56m`. That last field only appears on an exact `modelVersion` match, so it is direct evidence the new entry resolves.